### PR TITLE
Don't throw on additional pauses/pausing before starting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
   },
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 2020,
   },
   rules: {},
 }

--- a/index.js
+++ b/index.js
@@ -118,11 +118,11 @@ exports.init = function (ssb, config) {
   }
 
   function _pause() {
-    drainGraphStream.abort()
+    drainGraphStream?.abort()
     drainGraphStream = null
-    drainHopStream.abort()
+    drainHopStream?.abort()
     drainHopStream = null
-    groupMemberStream.abort()
+    groupMemberStream?.abort()
     groupMemberStream = null
   }
 


### PR DESCRIPTION
For https://gitlab.com/ahau/ahau/-/issues/38

Removed ssb-replicate and installed ssb-ebt and this module in ahau, and started getting these errors

![image](https://github.com/ssbc/ssb-replication-scheduler/assets/1427063/eec47d6b-b389-4aca-82ed-e19c2f82adc3)

![image](https://github.com/ssbc/ssb-replication-scheduler/assets/1427063/8cf166e3-d6b4-48b3-ac6c-afdb940c85cd)

this PR fixes those errors but idk if it was throwing for a good reason maybe? This PR removes those throws but I have yet to test if replication is working in ahau now. Tests are passing here though so :shrug: 